### PR TITLE
Add support for the entry API introduced in Moka v0.10

### DIFF
--- a/src/cache/moka_driver.rs
+++ b/src/cache/moka_driver.rs
@@ -1,20 +1,32 @@
+use async_trait::async_trait;
 use thiserror::Error;
+
+use crate::{parser::TraceEntry, Report};
 
 pub(crate) mod async_cache;
 pub(crate) mod sync_cache;
 pub(crate) mod sync_segmented;
 
+pub(crate) trait GetOrInsertOnce {
+    fn get_or_insert_once(&self, entry: &TraceEntry, report: &mut Report);
+}
+
+#[async_trait]
+trait AsyncGetOrInsertOnce {
+    async fn get_or_insert_once(&self, entry: &TraceEntry, report: &mut Report);
+}
+
 // https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum InitClosureType {
+enum InitClosureType {
     GetOrInsert,
     GetOrTryInsertWithError1,
     GetOrTyyInsertWithError2,
 }
 
 impl InitClosureType {
-    pub(crate) fn select(block: usize) -> Self {
+    fn select(block: usize) -> Self {
         match block % 4 {
             0 => Self::GetOrTryInsertWithError1,
             1 => Self::GetOrTyyInsertWithError2,
@@ -25,8 +37,8 @@ impl InitClosureType {
 
 #[derive(Debug, Error)]
 #[error("init closure failed with error one")]
-pub(crate) struct InitClosureError1;
+struct InitClosureError1;
 
 #[derive(Debug, Error)]
 #[error("init closure failed with error two")]
-pub(crate) struct InitClosureError2;
+struct InitClosureError2;

--- a/src/cache/moka_driver/async_cache.rs
+++ b/src/cache/moka_driver/async_cache.rs
@@ -1,4 +1,4 @@
-use super::{InitClosureError1, InitClosureError2, InitClosureType};
+use super::{AsyncGetOrInsertOnce, InitClosureError1, InitClosureError2, InitClosureType};
 use crate::cache::{Key, Value};
 use crate::moka::future::Cache;
 use crate::{
@@ -15,26 +15,70 @@ use std::sync::{
     Arc,
 };
 
-pub struct MokaAsyncCache {
+pub struct MokaAsyncCache<I> {
     config: Arc<Config>,
     cache: Cache<Key, Value, DefaultHasher>,
+    insert_once_impl: I,
     eviction_counters: Option<Arc<EvictionCounters>>,
 }
 
-impl Clone for MokaAsyncCache {
+impl<I: Clone> Clone for MokaAsyncCache<I> {
     fn clone(&self) -> Self {
         Self {
             config: Arc::clone(&self.config),
             cache: self.cache.clone(),
+            insert_once_impl: self.insert_once_impl.clone(),
             eviction_counters: self.eviction_counters.as_ref().map(Arc::clone),
         }
     }
 }
 
-impl MokaAsyncCache {
-    pub fn new(config: &Config, max_cap: u64, init_cap: usize) -> Self {
+impl MokaAsyncCache<GetWith> {
+    pub(crate) fn new(config: &Config, max_cap: u64, init_cap: usize) -> Self {
+        let (cache, eviction_counters) = Self::create_cache(config, max_cap, init_cap);
         let config = Arc::new(config.clone());
+        let insert_once_impl = GetWith {
+            cache: cache.clone(),
+            config: Arc::clone(&config),
+        };
 
+        Self {
+            config,
+            cache,
+            insert_once_impl,
+            eviction_counters,
+        }
+    }
+}
+
+#[cfg(not(any(feature = "moka-v08", feature = "moka-v09")))]
+use entry_api::EntryOrInsertWith;
+
+#[cfg(not(any(feature = "moka-v08", feature = "moka-v09")))]
+impl MokaAsyncCache<EntryOrInsertWith> {
+    pub(crate) fn with_entry_api(config: &Config, max_cap: u64, init_cap: usize) -> Self {
+        let (cache, eviction_counters) = Self::create_cache(config, max_cap, init_cap);
+        let config = Arc::new(config.clone());
+        let insert_once_impl = EntryOrInsertWith::new(cache.clone(), Arc::clone(&config));
+
+        Self {
+            config,
+            cache,
+            insert_once_impl,
+            eviction_counters,
+        }
+    }
+}
+
+impl<I> MokaAsyncCache<I> {
+    fn create_cache(
+        config: &Config,
+        max_cap: u64,
+        init_cap: usize,
+    ) -> (
+        Cache<Key, Value, DefaultHasher>,
+        Option<Arc<EvictionCounters>>,
+    ) {
         let mut builder = Cache::builder()
             .max_capacity(max_cap)
             .initial_capacity(init_cap);
@@ -51,19 +95,17 @@ impl MokaAsyncCache {
             builder = builder.weigher(|_k, (s, _v)| *s);
         }
 
+        let cache;
+        let eviction_counters;
+
         #[cfg(feature = "moka-v08")]
         {
-            Self {
-                config,
-                cache: builder.build_with_hasher(DefaultHasher::default()),
-                eviction_counters: None,
-            }
+            cache = builder.build_with_hasher(DefaultHasher::default());
+            eviction_counters = None;
         }
 
         #[cfg(not(feature = "moka-v08"))]
         {
-            let eviction_counters;
-
             if config.is_eviction_listener_enabled() {
                 let c0 = Arc::new(EvictionCounters::default());
                 let c1 = Arc::clone(&c0);
@@ -78,12 +120,10 @@ impl MokaAsyncCache {
                 eviction_counters = None;
             }
 
-            Self {
-                config,
-                cache: builder.build_with_hasher(DefaultHasher::default()),
-                eviction_counters,
-            }
+            cache = builder.build_with_hasher(DefaultHasher::default());
         }
+
+        (cache, eviction_counters)
     }
 
     fn get(&self, key: usize) -> bool {
@@ -95,50 +135,13 @@ impl MokaAsyncCache {
         cache::sleep_task_for_insertion(&self.config).await;
         self.cache.insert(key, value).await;
     }
-
-    async fn get_with(&self, key: usize, req_id: usize, is_inserted: Arc<AtomicBool>) {
-        self.cache
-            .get_with(key, async {
-                cache::sleep_task_for_insertion(&self.config).await;
-                is_inserted.store(true, Ordering::Release);
-                cache::make_value(&self.config, key, req_id)
-            })
-            .await;
-    }
-
-    async fn try_get_with(
-        &self,
-        ty: InitClosureType,
-        key: usize,
-        req_id: usize,
-        is_inserted: Arc<AtomicBool>,
-    ) {
-        match ty {
-            InitClosureType::GetOrTryInsertWithError1 => self
-                .cache
-                .try_get_with(key, async {
-                    cache::sleep_task_for_insertion(&self.config).await;
-                    is_inserted.store(true, Ordering::Release);
-                    Ok(cache::make_value(&self.config, key, req_id)) as Result<_, InitClosureError1>
-                })
-                .await
-                .is_ok(),
-            InitClosureType::GetOrTyyInsertWithError2 => self
-                .cache
-                .try_get_with(key, async {
-                    cache::sleep_task_for_insertion(&self.config).await;
-                    is_inserted.store(true, Ordering::Release);
-                    Ok(cache::make_value(&self.config, key, req_id)) as Result<_, InitClosureError2>
-                })
-                .await
-                .is_ok(),
-            _ => unreachable!(),
-        };
-    }
 }
 
 #[async_trait]
-impl AsyncCacheDriver<TraceEntry> for MokaAsyncCache {
+impl<I> AsyncCacheDriver<TraceEntry> for MokaAsyncCache<I>
+where
+    I: AsyncGetOrInsertOnce + Send + Sync,
+{
     async fn get_or_insert(&mut self, entry: &TraceEntry, report: &mut Report) {
         let mut counters = Counters::default();
         let mut req_id = entry.line_number();
@@ -158,32 +161,9 @@ impl AsyncCacheDriver<TraceEntry> for MokaAsyncCache {
     }
 
     async fn get_or_insert_once(&mut self, entry: &TraceEntry, report: &mut Report) {
-        let mut counters = Counters::default();
-        let mut req_id = entry.line_number();
-        let is_inserted = Arc::new(AtomicBool::default());
-
-        for block in entry.range() {
-            {
-                let is_inserted2 = Arc::clone(&is_inserted);
-                match InitClosureType::select(block) {
-                    InitClosureType::GetOrInsert => {
-                        self.get_with(block, req_id, is_inserted2).await
-                    }
-                    ty => self.try_get_with(ty, block, req_id, is_inserted2).await,
-                }
-            }
-
-            if is_inserted.load(Ordering::Acquire) {
-                counters.inserted();
-                counters.read_missed();
-                is_inserted.store(false, Ordering::Release);
-            } else {
-                counters.read_hit();
-            }
-            req_id += 1;
-        }
-
-        counters.add_to_report(report);
+        self.insert_once_impl
+            .get_or_insert_once(entry, report)
+            .await;
     }
 
     async fn update(&mut self, entry: &TraceEntry, report: &mut Report) {
@@ -230,5 +210,179 @@ impl AsyncCacheDriver<TraceEntry> for MokaAsyncCache {
 
     fn eviction_counters(&self) -> Option<Arc<EvictionCounters>> {
         self.eviction_counters.as_ref().map(Arc::clone)
+    }
+}
+
+//
+// GetWith (implements GetOrInsertOnce)
+//
+#[derive(Clone)]
+pub(crate) struct GetWith {
+    cache: Cache<Key, Value, DefaultHasher>,
+    config: Arc<Config>,
+}
+
+#[async_trait]
+impl AsyncGetOrInsertOnce for GetWith {
+    async fn get_or_insert_once(&self, entry: &TraceEntry, report: &mut Report) {
+        let mut counters = Counters::default();
+        let mut req_id = entry.line_number();
+        let is_inserted = Arc::new(AtomicBool::default());
+
+        for block in entry.range() {
+            {
+                let is_inserted2 = Arc::clone(&is_inserted);
+                match InitClosureType::select(block) {
+                    InitClosureType::GetOrInsert => {
+                        self.get_with(block, req_id, is_inserted2).await
+                    }
+                    ty => self.try_get_with(ty, block, req_id, is_inserted2).await,
+                }
+            }
+
+            if is_inserted.load(Ordering::Acquire) {
+                counters.inserted();
+                counters.read_missed();
+                is_inserted.store(false, Ordering::Release);
+            } else {
+                counters.read_hit();
+            }
+            req_id += 1;
+        }
+
+        counters.add_to_report(report);
+    }
+}
+
+impl GetWith {
+    async fn get_with(&self, key: usize, req_id: usize, is_inserted: Arc<AtomicBool>) {
+        self.cache
+            .get_with(key, async {
+                cache::sleep_task_for_insertion(&self.config).await;
+                is_inserted.store(true, Ordering::Release);
+                cache::make_value(&self.config, key, req_id)
+            })
+            .await;
+    }
+
+    async fn try_get_with(
+        &self,
+        ty: InitClosureType,
+        key: usize,
+        req_id: usize,
+        is_inserted: Arc<AtomicBool>,
+    ) {
+        match ty {
+            InitClosureType::GetOrTryInsertWithError1 => self
+                .cache
+                .try_get_with(key, async {
+                    cache::sleep_task_for_insertion(&self.config).await;
+                    is_inserted.store(true, Ordering::Release);
+                    Ok(cache::make_value(&self.config, key, req_id)) as Result<_, InitClosureError1>
+                })
+                .await
+                .is_ok(),
+            InitClosureType::GetOrTyyInsertWithError2 => self
+                .cache
+                .try_get_with(key, async {
+                    cache::sleep_task_for_insertion(&self.config).await;
+                    is_inserted.store(true, Ordering::Release);
+                    Ok(cache::make_value(&self.config, key, req_id)) as Result<_, InitClosureError2>
+                })
+                .await
+                .is_ok(),
+            _ => unreachable!(),
+        };
+    }
+}
+
+//
+// EntryOrInsertWith (implements GetOrInsertOnce)
+//
+#[cfg(not(any(feature = "moka-v08", feature = "moka-v09")))]
+mod entry_api {
+    use super::*;
+
+    #[derive(Clone)]
+    pub(crate) struct EntryOrInsertWith {
+        cache: Cache<Key, Value, DefaultHasher>,
+        config: Arc<Config>,
+    }
+
+    impl EntryOrInsertWith {
+        pub(crate) fn new(cache: Cache<Key, Value, DefaultHasher>, config: Arc<Config>) -> Self {
+            Self { cache, config }
+        }
+    }
+
+    #[async_trait]
+    impl AsyncGetOrInsertOnce for EntryOrInsertWith {
+        async fn get_or_insert_once(&self, entry: &TraceEntry, report: &mut Report) {
+            let mut counters = Counters::default();
+            let mut req_id = entry.line_number();
+
+            for block in entry.range() {
+                let is_inserted = match InitClosureType::select(block) {
+                    InitClosureType::GetOrInsert => self.entry_or_insert_with(block, req_id).await,
+                    ty => self.entry_or_try_insert_with(ty, block, req_id).await,
+                };
+
+                if is_inserted {
+                    counters.inserted();
+                    counters.read_missed();
+                } else {
+                    counters.read_hit();
+                }
+                req_id += 1;
+            }
+
+            counters.add_to_report(report);
+        }
+    }
+
+    impl EntryOrInsertWith {
+        async fn entry_or_insert_with(&self, key: usize, req_id: usize) -> bool {
+            self.cache
+                .entry(key)
+                .or_insert_with(async {
+                    cache::sleep_task_for_insertion(&self.config).await;
+                    cache::make_value(&self.config, key, req_id)
+                })
+                .await
+                .is_fresh()
+        }
+
+        async fn entry_or_try_insert_with(
+            &self,
+            ty: InitClosureType,
+            key: usize,
+            req_id: usize,
+        ) -> bool {
+            match ty {
+                InitClosureType::GetOrTryInsertWithError1 => self
+                    .cache
+                    .entry(key)
+                    .or_try_insert_with(async {
+                        cache::sleep_task_for_insertion(&self.config).await;
+                        Ok(cache::make_value(&self.config, key, req_id))
+                            as Result<_, InitClosureError1>
+                    })
+                    .await
+                    .unwrap()
+                    .is_fresh(),
+                InitClosureType::GetOrTyyInsertWithError2 => self
+                    .cache
+                    .entry(key)
+                    .or_try_insert_with(async {
+                        cache::sleep_task_for_insertion(&self.config).await;
+                        Ok(cache::make_value(&self.config, key, req_id))
+                            as Result<_, InitClosureError2>
+                    })
+                    .await
+                    .unwrap()
+                    .is_fresh(),
+                _ => unreachable!(),
+            }
+        }
     }
 }

--- a/src/cache/moka_driver/sync_segmented.rs
+++ b/src/cache/moka_driver/sync_segmented.rs
@@ -1,4 +1,4 @@
-use super::{InitClosureError1, InitClosureError2, InitClosureType};
+use super::{GetOrInsertOnce, InitClosureError1, InitClosureError2, InitClosureType};
 use crate::{
     cache::{self, CacheDriver, Counters, DefaultHasher, Key, Value},
     config::Config,
@@ -13,26 +13,78 @@ use std::sync::{
     Arc,
 };
 
-pub struct MokaSegmentedCache {
+pub(crate) struct MokaSegmentedCache<I> {
     config: Arc<Config>,
     cache: SegmentedCache<Key, Value, DefaultHasher>,
+    insert_once_impl: I,
     eviction_counters: Option<Arc<EvictionCounters>>,
 }
 
-impl Clone for MokaSegmentedCache {
+impl<I: Clone> Clone for MokaSegmentedCache<I> {
     fn clone(&self) -> Self {
         Self {
             config: Arc::clone(&self.config),
             cache: self.cache.clone(),
+            insert_once_impl: self.insert_once_impl.clone(),
             eviction_counters: self.eviction_counters.as_ref().map(Arc::clone),
         }
     }
 }
 
-impl MokaSegmentedCache {
-    pub fn new(config: &Config, max_cap: u64, init_cap: usize, num_segments: usize) -> Self {
+impl MokaSegmentedCache<GetWith> {
+    pub(crate) fn new(config: &Config, max_cap: u64, init_cap: usize, num_segments: usize) -> Self {
+        let (cache, eviction_counters) =
+            Self::create_cache(config, max_cap, init_cap, num_segments);
         let config = Arc::new(config.clone());
+        let insert_once_impl = GetWith {
+            cache: cache.clone(),
+            config: Arc::clone(&config),
+        };
 
+        Self {
+            config,
+            cache,
+            insert_once_impl,
+            eviction_counters,
+        }
+    }
+}
+
+#[cfg(not(any(feature = "moka-v08", feature = "moka-v09")))]
+use entry_api::EntryOrInsertWith;
+
+#[cfg(not(any(feature = "moka-v08", feature = "moka-v09")))]
+impl MokaSegmentedCache<EntryOrInsertWith> {
+    pub(crate) fn with_entry_api(
+        config: &Config,
+        max_cap: u64,
+        init_cap: usize,
+        num_segments: usize,
+    ) -> Self {
+        let (cache, eviction_counters) =
+            Self::create_cache(config, max_cap, init_cap, num_segments);
+        let config = Arc::new(config.clone());
+        let insert_once_impl = EntryOrInsertWith::new(cache.clone(), Arc::clone(&config));
+
+        Self {
+            config,
+            cache,
+            insert_once_impl,
+            eviction_counters,
+        }
+    }
+}
+
+impl<I> MokaSegmentedCache<I> {
+    fn create_cache(
+        config: &Config,
+        max_cap: u64,
+        init_cap: usize,
+        num_segments: usize,
+    ) -> (
+        SegmentedCache<Key, Value, DefaultHasher>,
+        Option<Arc<EvictionCounters>>,
+    ) {
         let mut builder = SegmentedCache::builder(num_segments)
             .max_capacity(max_cap)
             .initial_capacity(init_cap);
@@ -49,21 +101,19 @@ impl MokaSegmentedCache {
             builder = builder.weigher(|_k, (s, _v)| *s);
         }
 
+        let cache;
+        let eviction_counters;
+
         #[cfg(feature = "moka-v08")]
         {
-            Self {
-                config,
-                cache: builder.build_with_hasher(DefaultHasher::default()),
-                eviction_counters: None,
-            }
+            cache = builder.build_with_hasher(DefaultHasher::default());
+            eviction_counters = None;
         }
 
         #[cfg(not(feature = "moka-v08"))]
         {
             use crate::config::RemovalNotificationMode;
             use crate::moka::notification::{Configuration, DeliveryMode};
-
-            let eviction_counters;
 
             if config.is_eviction_listener_enabled() {
                 let c0 = Arc::new(EvictionCounters::default());
@@ -89,12 +139,10 @@ impl MokaSegmentedCache {
                 eviction_counters = None;
             }
 
-            Self {
-                config,
-                cache: builder.build_with_hasher(DefaultHasher::default()),
-                eviction_counters,
-            }
+            cache = builder.build_with_hasher(DefaultHasher::default());
         }
+
+        (cache, eviction_counters)
     }
 
     fn get(&self, key: &usize) -> bool {
@@ -106,45 +154,9 @@ impl MokaSegmentedCache {
         cache::sleep_thread_for_insertion(&self.config);
         self.cache.insert(key, value);
     }
-
-    fn get_with(&self, key: usize, req_id: usize, is_inserted: Arc<AtomicBool>) {
-        self.cache.get_with(key, || {
-            cache::sleep_thread_for_insertion(&self.config);
-            is_inserted.store(true, Ordering::Release);
-            cache::make_value(&self.config, key, req_id)
-        });
-    }
-
-    fn try_get_with(
-        &self,
-        ty: InitClosureType,
-        key: usize,
-        req_id: usize,
-        is_inserted: Arc<AtomicBool>,
-    ) {
-        match ty {
-            InitClosureType::GetOrTryInsertWithError1 => self
-                .cache
-                .try_get_with(key, || {
-                    cache::sleep_thread_for_insertion(&self.config);
-                    is_inserted.store(true, Ordering::Release);
-                    Ok(cache::make_value(&self.config, key, req_id)) as Result<_, InitClosureError1>
-                })
-                .is_ok(),
-            InitClosureType::GetOrTyyInsertWithError2 => self
-                .cache
-                .try_get_with(key, || {
-                    cache::sleep_thread_for_insertion(&self.config);
-                    is_inserted.store(true, Ordering::Release);
-                    Ok(cache::make_value(&self.config, key, req_id)) as Result<_, InitClosureError2>
-                })
-                .is_ok(),
-            _ => unreachable!(),
-        };
-    }
 }
 
-impl CacheDriver<TraceEntry> for MokaSegmentedCache {
+impl<I: GetOrInsertOnce> CacheDriver<TraceEntry> for MokaSegmentedCache<I> {
     fn get_or_insert(&mut self, entry: &TraceEntry, report: &mut Report) {
         let mut counters = Counters::default();
         let mut req_id = entry.line_number();
@@ -164,30 +176,7 @@ impl CacheDriver<TraceEntry> for MokaSegmentedCache {
     }
 
     fn get_or_insert_once(&mut self, entry: &TraceEntry, report: &mut Report) {
-        let mut counters = Counters::default();
-        let mut req_id = entry.line_number();
-        let is_inserted = Arc::new(AtomicBool::default());
-
-        for block in entry.range() {
-            {
-                let is_inserted2 = Arc::clone(&is_inserted);
-                match InitClosureType::select(block) {
-                    InitClosureType::GetOrInsert => self.get_with(block, req_id, is_inserted2),
-                    ty => self.try_get_with(ty, block, req_id, is_inserted2),
-                }
-            }
-
-            if is_inserted.load(Ordering::Acquire) {
-                counters.inserted();
-                counters.read_missed();
-                is_inserted.store(false, Ordering::Release);
-            } else {
-                counters.read_hit();
-            }
-            req_id += 1;
-        }
-
-        counters.add_to_report(report);
+        self.insert_once_impl.get_or_insert_once(entry, report);
     }
 
     fn update(&mut self, entry: &TraceEntry, report: &mut Report) {
@@ -234,5 +223,166 @@ impl CacheDriver<TraceEntry> for MokaSegmentedCache {
 
     fn eviction_counters(&self) -> Option<Arc<EvictionCounters>> {
         self.eviction_counters.as_ref().map(Arc::clone)
+    }
+}
+
+//
+// GetWith (implements GetOrInsertOnce)
+//
+#[derive(Clone)]
+pub(crate) struct GetWith {
+    cache: SegmentedCache<Key, Value, DefaultHasher>,
+    config: Arc<Config>,
+}
+
+impl GetOrInsertOnce for GetWith {
+    fn get_or_insert_once(&self, entry: &TraceEntry, report: &mut Report) {
+        let mut counters = Counters::default();
+        let mut req_id = entry.line_number();
+        let is_inserted = Arc::new(AtomicBool::default());
+
+        for block in entry.range() {
+            {
+                let is_inserted2 = Arc::clone(&is_inserted);
+                match InitClosureType::select(block) {
+                    InitClosureType::GetOrInsert => self.get_with(block, req_id, is_inserted2),
+                    ty => self.try_get_with(ty, block, req_id, is_inserted2),
+                }
+            }
+
+            if is_inserted.load(Ordering::Acquire) {
+                counters.inserted();
+                counters.read_missed();
+                is_inserted.store(false, Ordering::Release);
+            } else {
+                counters.read_hit();
+            }
+            req_id += 1;
+        }
+
+        counters.add_to_report(report);
+    }
+}
+
+impl GetWith {
+    fn get_with(&self, key: usize, req_id: usize, is_inserted: Arc<AtomicBool>) {
+        self.cache.get_with(key, || {
+            cache::sleep_thread_for_insertion(&self.config);
+            is_inserted.store(true, Ordering::Release);
+            cache::make_value(&self.config, key, req_id)
+        });
+    }
+
+    fn try_get_with(
+        &self,
+        ty: InitClosureType,
+        key: usize,
+        req_id: usize,
+        is_inserted: Arc<AtomicBool>,
+    ) {
+        match ty {
+            InitClosureType::GetOrTryInsertWithError1 => self
+                .cache
+                .try_get_with(key, || {
+                    cache::sleep_thread_for_insertion(&self.config);
+                    is_inserted.store(true, Ordering::Release);
+                    Ok(cache::make_value(&self.config, key, req_id)) as Result<_, InitClosureError1>
+                })
+                .is_ok(),
+            InitClosureType::GetOrTyyInsertWithError2 => self
+                .cache
+                .try_get_with(key, || {
+                    cache::sleep_thread_for_insertion(&self.config);
+                    is_inserted.store(true, Ordering::Release);
+                    Ok(cache::make_value(&self.config, key, req_id)) as Result<_, InitClosureError2>
+                })
+                .is_ok(),
+            _ => unreachable!(),
+        };
+    }
+}
+
+//
+// EntryOrInsertWith (implements GetOrInsertOnce)
+//
+#[cfg(not(any(feature = "moka-v08", feature = "moka-v09")))]
+mod entry_api {
+    use super::*;
+
+    #[derive(Clone)]
+    pub(crate) struct EntryOrInsertWith {
+        cache: SegmentedCache<Key, Value, DefaultHasher>,
+        config: Arc<Config>,
+    }
+
+    impl EntryOrInsertWith {
+        pub(crate) fn new(
+            cache: SegmentedCache<Key, Value, DefaultHasher>,
+            config: Arc<Config>,
+        ) -> Self {
+            Self { cache, config }
+        }
+    }
+
+    impl GetOrInsertOnce for EntryOrInsertWith {
+        fn get_or_insert_once(&self, entry: &TraceEntry, report: &mut Report) {
+            let mut counters = Counters::default();
+            let mut req_id = entry.line_number();
+
+            for block in entry.range() {
+                let is_inserted = match InitClosureType::select(block) {
+                    InitClosureType::GetOrInsert => self.entry_or_insert_with(block, req_id),
+                    ty => self.entry_or_try_insert_with(ty, block, req_id),
+                };
+
+                if is_inserted {
+                    counters.inserted();
+                    counters.read_missed();
+                } else {
+                    counters.read_hit();
+                }
+                req_id += 1;
+            }
+
+            counters.add_to_report(report);
+        }
+    }
+
+    impl EntryOrInsertWith {
+        fn entry_or_insert_with(&self, key: usize, req_id: usize) -> bool {
+            self.cache
+                .entry(key)
+                .or_insert_with(|| {
+                    cache::sleep_thread_for_insertion(&self.config);
+                    cache::make_value(&self.config, key, req_id)
+                })
+                .is_fresh()
+        }
+
+        fn entry_or_try_insert_with(&self, ty: InitClosureType, key: usize, req_id: usize) -> bool {
+            match ty {
+                InitClosureType::GetOrTryInsertWithError1 => self
+                    .cache
+                    .entry(key)
+                    .or_try_insert_with(|| {
+                        cache::sleep_thread_for_insertion(&self.config);
+                        Ok(cache::make_value(&self.config, key, req_id))
+                            as Result<_, InitClosureError1>
+                    })
+                    .unwrap()
+                    .is_fresh(),
+                InitClosureType::GetOrTyyInsertWithError2 => self
+                    .cache
+                    .entry(key)
+                    .or_try_insert_with(|| {
+                        cache::sleep_thread_for_insertion(&self.config);
+                        Ok(cache::make_value(&self.config, key, req_id))
+                            as Result<_, InitClosureError2>
+                    })
+                    .unwrap()
+                    .is_fresh(),
+                _ => unreachable!(),
+            }
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub invalidate_all: bool,
     pub invalidate_entries_if: bool,
     pub iterate: bool,
+    pub entry_api: bool,
     pub eviction_listener: RemovalNotificationMode,
     pub size_aware: bool,
 }
@@ -34,6 +35,7 @@ impl Config {
         invalidate_all: bool,
         invalidate_entries_if: bool,
         iterate: bool,
+        entry_api: bool,
         eviction_listener: RemovalNotificationMode,
         size_aware: bool,
     ) -> Self {
@@ -49,6 +51,7 @@ impl Config {
             invalidate_all,
             invalidate_entries_if,
             iterate,
+            entry_api,
             eviction_listener,
             size_aware,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,15 @@ pub fn run_multi_threads_moka_sync(
     } else {
         capacity as u64
     };
-    let cache_driver = MokaSyncCache::new(config, max_cap, capacity);
     let report_builder = ReportBuilder::new("Moka Sync Cache", max_cap, Some(num_clients));
+
+    #[cfg(not(any(feature = "moka-v08", feature = "moka-v09")))]
+    if config.entry_api {
+        let cache_driver = MokaSyncCache::with_entry_api(config, max_cap, capacity);
+        return run_multi_threads(config, num_clients, cache_driver, report_builder);
+    }
+
+    let cache_driver = MokaSyncCache::new(config, max_cap, capacity);
     run_multi_threads(config, num_clients, cache_driver, report_builder)
 }
 
@@ -89,9 +96,17 @@ pub fn run_multi_threads_moka_segment(
     } else {
         capacity as u64
     };
-    let cache_driver = MokaSegmentedCache::new(config, max_cap, capacity, num_segments);
     let report_name = format!("Moka SegmentedCache({num_segments})");
     let report_builder = ReportBuilder::new(&report_name, max_cap, Some(num_clients));
+
+    #[cfg(not(any(feature = "moka-v08", feature = "moka-v09")))]
+    if config.entry_api {
+        let cache_driver =
+            MokaSegmentedCache::with_entry_api(config, max_cap, capacity, num_segments);
+        return run_multi_threads(config, num_clients, cache_driver, report_builder);
+    }
+
+    let cache_driver = MokaSegmentedCache::new(config, max_cap, capacity, num_segments);
     run_multi_threads(config, num_clients, cache_driver, report_builder)
 }
 
@@ -105,8 +120,15 @@ pub async fn run_multi_tasks_moka_async(
     } else {
         capacity as u64
     };
-    let cache_driver = MokaAsyncCache::new(config, max_cap, capacity);
     let report_builder = ReportBuilder::new("Moka Async Cache", max_cap, Some(num_clients));
+
+    #[cfg(not(any(feature = "moka-v08", feature = "moka-v09")))]
+    if config.entry_api {
+        let cache_driver = MokaAsyncCache::with_entry_api(config, max_cap, capacity);
+        return run_multi_tasks(config, num_clients, cache_driver, report_builder).await;
+    }
+
+    let cache_driver = MokaAsyncCache::new(config, max_cap, capacity);
     run_multi_tasks(config, num_clients, cache_driver, report_builder).await
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,7 @@ const OPTION_INVALIDATE: &str = "invalidate";
 const OPTION_INVALIDATE_ALL: &str = "invalidate-all";
 const OPTION_INVALIDATE_IF: &str = "invalidate-entries-if";
 const OPTION_ITERATE: &str = "iterate";
+const OPTION_ENTRY_API: &str = "entry-api";
 const OPTION_REPEAT: &str = "repeat";
 const OPTION_SIZE_AWARE: &str = "size-aware";
 
@@ -197,6 +198,10 @@ fn create_config() -> anyhow::Result<(Vec<TraceFile>, Config)> {
         .arg(Arg::new(OPTION_INVALIDATE_IF).long(OPTION_INVALIDATE_IF))
         .arg(Arg::new(OPTION_ITERATE).long(OPTION_ITERATE))
         .arg(Arg::new(OPTION_SIZE_AWARE).long(OPTION_SIZE_AWARE));
+
+    if cfg!(not(any(feature = "moka-v09", feature = "moka-v08"))) {
+        app = app.arg(Arg::new(OPTION_ENTRY_API).long(OPTION_ENTRY_API));
+    }
 
     if cfg!(not(feature = "moka-v08")) {
         app = app.arg(
@@ -263,6 +268,7 @@ fn create_config() -> anyhow::Result<(Vec<TraceFile>, Config)> {
     let invalidate_all = matches.is_present(OPTION_INVALIDATE_ALL);
     let invalidate_entries_if = matches.is_present(OPTION_INVALIDATE_IF);
     let iterate = matches.is_present(OPTION_ITERATE);
+    let entry_api = matches.is_present(OPTION_ENTRY_API);
     let size_aware = matches.is_present(OPTION_SIZE_AWARE);
 
     let eviction_listener = if cfg!(not(feature = "moka-v08")) {
@@ -284,6 +290,10 @@ fn create_config() -> anyhow::Result<(Vec<TraceFile>, Config)> {
         RemovalNotificationMode::None
     };
 
+    if cfg!(not(any(feature = "moka-v08", feature = "moka-v08"))) && !entry_api {
+        eprintln!("\nWARNING: Testing Moka's entry API is disabled by default. Use --entry-api to enable it\n");
+    }
+
     let config = Config::new(
         trace_files[0],
         ttl_secs,
@@ -296,6 +306,7 @@ fn create_config() -> anyhow::Result<(Vec<TraceFile>, Config)> {
         invalidate_all,
         invalidate_entries_if,
         iterate,
+        entry_api,
         eviction_listener,
         size_aware,
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,8 +290,8 @@ fn create_config() -> anyhow::Result<(Vec<TraceFile>, Config)> {
         RemovalNotificationMode::None
     };
 
-    if cfg!(not(any(feature = "moka-v08", feature = "moka-v08"))) && !entry_api {
-        eprintln!("\nWARNING: Testing Moka's entry API is disabled by default. Use --entry-api to enable it\n");
+    if !entry_api && insert_once && cfg!(not(any(feature = "moka-v08", feature = "moka-v09"))) {
+        eprintln!("\nWARNING: Testing Moka's entry API is disabled by default. Use --entry-api to enable it.\n");
     }
 
     let config = Config::new(


### PR DESCRIPTION
Support the entry API via `--entry-api` option when Moka v0.10 or newer is used.