### PR TITLE
Reduce benchmark harness overhead

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,10 +4,7 @@ use std::{
 };
 
 use crate::{
-    config::Config,
-    eviction_counters::EvictionCounters,
-    parser::{self, TraceEntry, TraceParser},
-    Command, Report,
+    config::Config, eviction_counters::EvictionCounters, parser::TraceEntry, Command, Report,
 };
 
 use async_trait::async_trait;
@@ -70,34 +67,23 @@ pub(crate) fn process_commands(
     cache: &mut impl CacheDriver<TraceEntry>,
     report: &mut Report,
 ) {
-    let mut parser = parser::GenericTraceParser;
     for command in commands {
         match command {
-            Command::GetOrInsert(line, line_number) => {
-                if let Some(entry) = parser.parse(&line, line_number).unwrap() {
-                    cache.get_or_insert(&entry, report);
-                }
+            Command::GetOrInsert(entry) => {
+                cache.get_or_insert(&entry, report);
             }
-            Command::GetOrInsertOnce(line, line_number) => {
-                if let Some(entry) = parser.parse(&line, line_number).unwrap() {
-                    cache.get_or_insert_once(&entry, report);
-                }
+            Command::GetOrInsertOnce(entry) => {
+                cache.get_or_insert_once(&entry, report);
             }
-            Command::Update(line, line_number) => {
-                if let Some(entry) = parser.parse(&line, line_number).unwrap() {
-                    cache.update(&entry, report);
-                }
+            Command::Update(entry) => {
+                cache.update(&entry, report);
             }
-            Command::Invalidate(line, line_number) => {
-                if let Some(entry) = parser.parse(&line, line_number).unwrap() {
-                    cache.invalidate(&entry);
-                }
+            Command::Invalidate(entry) => {
+                cache.invalidate(&entry);
             }
             Command::InvalidateAll => cache.invalidate_all(),
-            Command::InvalidateEntriesIf(line, line_number) => {
-                if let Some(entry) = parser.parse(&line, line_number).unwrap() {
-                    cache.invalidate_entries_if(&entry);
-                }
+            Command::InvalidateEntriesIf(entry) => {
+                cache.invalidate_entries_if(&entry);
             }
             Command::Iterate => cache.iterate(),
         }
@@ -109,34 +95,23 @@ pub(crate) async fn process_commands_async(
     cache: &mut impl AsyncCacheDriver<TraceEntry>,
     report: &mut Report,
 ) {
-    let mut parser = parser::GenericTraceParser;
     for command in commands {
         match command {
-            Command::GetOrInsert(line, line_number) => {
-                if let Some(entry) = parser.parse(&line, line_number).unwrap() {
-                    cache.get_or_insert(&entry, report).await;
-                }
+            Command::GetOrInsert(entry) => {
+                cache.get_or_insert(&entry, report).await;
             }
-            Command::GetOrInsertOnce(line, line_number) => {
-                if let Some(entry) = parser.parse(&line, line_number).unwrap() {
-                    cache.get_or_insert_once(&entry, report).await;
-                }
+            Command::GetOrInsertOnce(entry) => {
+                cache.get_or_insert_once(&entry, report).await;
             }
-            Command::Update(line, line_number) => {
-                if let Some(entry) = parser.parse(&line, line_number).unwrap() {
-                    cache.update(&entry, report).await;
-                }
+            Command::Update(entry) => {
+                cache.update(&entry, report).await;
             }
-            Command::Invalidate(line, line_number) => {
-                if let Some(entry) = parser.parse(&line, line_number).unwrap() {
-                    cache.invalidate(&entry).await;
-                }
+            Command::Invalidate(entry) => {
+                cache.invalidate(&entry).await;
             }
             Command::InvalidateAll => cache.invalidate_all(),
-            Command::InvalidateEntriesIf(line, line_number) => {
-                if let Some(entry) = parser.parse(&line, line_number).unwrap() {
-                    cache.invalidate_entries_if(&entry);
-                }
+            Command::InvalidateEntriesIf(entry) => {
+                cache.invalidate_entries_if(&entry);
             }
             Command::Iterate => cache.iterate().await,
         }

--- a/src/load_gen.rs
+++ b/src/load_gen.rs
@@ -1,4 +1,8 @@
-use crate::{config::Config, Command};
+use crate::{
+    config::Config,
+    parser::{GenericTraceParser, TraceParser},
+    Command,
+};
 
 pub(crate) fn generate_commands<I>(
     config: &Config,
@@ -7,25 +11,27 @@ pub(crate) fn generate_commands<I>(
     chunk: I,
 ) -> anyhow::Result<Vec<Command>>
 where
-    I: Iterator<Item = std::io::Result<String>>,
+    I: Iterator<Item = std::io::Result<(usize, String)>>,
 {
+    let mut parser = GenericTraceParser;
     let mut ops = Vec::with_capacity(max_chunk_size);
-    for line in chunk {
-        let line = line?;
+    for line_result in chunk {
+        let (line_number, line) = line_result?;
+        let Some(entry) = parser.parse(&line, line_number)? else { continue };
         *counter += 1;
         if config.invalidate_all && *counter % 100_000 == 0 {
             ops.push(Command::InvalidateAll);
-            ops.push(Command::GetOrInsert(line, *counter));
+            ops.push(Command::GetOrInsert(entry));
         } else if config.invalidate_entries_if && *counter % 5_000 == 0 {
-            ops.push(Command::InvalidateEntriesIf(line, *counter));
+            ops.push(Command::InvalidateEntriesIf(entry));
         } else if config.size_aware && *counter % 11 == 0 {
-            ops.push(Command::Update(line, *counter));
+            ops.push(Command::Update(entry));
         } else if config.invalidate && *counter % 8 == 0 {
-            ops.push(Command::Invalidate(line, *counter));
+            ops.push(Command::Invalidate(entry));
         } else if config.insert_once && *counter % 3 == 0 {
-            ops.push(Command::GetOrInsertOnce(line, *counter));
+            ops.push(Command::GetOrInsertOnce(entry));
         } else {
-            ops.push(Command::GetOrInsert(line, *counter));
+            ops.push(Command::GetOrInsert(entry));
         }
 
         if config.iterate && *counter % 50_000 == 0 {


### PR DESCRIPTION
I was hitting some significant bottlenecks due to the benchmark harness overhead. I narrowed it down to the 2 limitations below, which lead to skewed results:

* overhead of parsing each line and generating a command
* single producer doing the command generation cannot keep the consumer threads busy

This change takes the easy (pragmatic) route and fully pre-process the benchmark commands before performing the benchmark. This solves both of the issues above.

Although effective, this change isn't particularly ideal, as it requires 4GB memory to benchmark the DS1 dataset.