### PR TITLE
Misc small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ $ cargo build --release --no-default-features -F moka-v09
 
 | Feature       | Enabled Cache Product |
 |:--------------|:----------------------|
-| `moka-v010`   | [Moka](https://crates.io/crates/moka) v0.10.x |
+| `moka-v010`   | [Moka](https://crates.io/crates/moka) v0.10.x (Enabled by default) |
 | `moka-v09`    |  Moka v0.9.x |
 | `moka-v08`    |  Moka v0.8.x |
-| `hashlink`    | [hashlink](https://crates.io/crates/hashlink) |
+| `hashlink`    | [HashLink](https://crates.io/crates/hashlink) |
 | `mini-moka`   | [Mini-Moka](https://crates.io/crates/mini-moka) |
 | `quick_cache` | [quick_cache](https://crates.io/crates/quick_cache) |
 | `stretto`     | [Stretto](https://crates.io/crates/stretto) |
@@ -65,10 +65,30 @@ NOTES:
 - `mini-moka` cannot be enabled when `moka-v09` or `moka-v08` is enabled.
 
 
-
 ### Run Benchmarks
 
-Run the benchmarks with the following commands:
+Here are some examples to run benchmarks:
+
+```console
+## Run with the default (S3.lis) dataset, using single client thread,
+## and then 3 client threads, and so on.
+$ ./target/release/mokabench --num-clients 1,3,6
+
+## Run with DS1.lis dataset.
+$ ./target/release/mokabench --num-clients 1,3,6 --trace-file ds1
+
+## Run with an insertion delay (in microseconds) to simulate more
+## realistic workload. The following example will try to add ~1
+## microseconds delay before inserting a value to the cache.
+##
+## Note: It uses `std::thread::sleep` and many operating systems
+## have a minimum sleep resolution larger than 1 microsecond. So
+## the actual delay may be larger than the specified value.
+##
+$ ./target/release/mokabench --num-clients 1,3,6 --insertion-delay 1
+```
+
+You can also test Moka's advanced features/APIs:
 
 ```console
 ## Call `get` and `insert` with time-to-live = 3 seconds and

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -172,12 +172,6 @@ pub(crate) fn sleep_thread_for_insertion(config: &Config) {
     }
 }
 
-pub(crate) async fn sleep_task_for_insertion(config: &Config) {
-    if let Some(delay) = config.insertion_delay {
-        async_io::Timer::after(delay).await;
-    }
-}
-
 const HASH_SEED_KEY: u64 = 982922761776577566;
 
 #[derive(Clone, Default)]

--- a/src/cache/moka_driver/async_cache.rs
+++ b/src/cache/moka_driver/async_cache.rs
@@ -132,7 +132,7 @@ impl<I> MokaAsyncCache<I> {
 
     async fn insert(&self, key: usize, req_id: usize) {
         let value = cache::make_value(&self.config, key, req_id);
-        cache::sleep_task_for_insertion(&self.config).await;
+        cache::sleep_thread_for_insertion(&self.config);
         self.cache.insert(key, value).await;
     }
 }
@@ -258,7 +258,7 @@ impl GetWith {
     async fn get_with(&self, key: usize, req_id: usize, is_inserted: Arc<AtomicBool>) {
         self.cache
             .get_with(key, async {
-                cache::sleep_task_for_insertion(&self.config).await;
+                cache::sleep_thread_for_insertion(&self.config);
                 is_inserted.store(true, Ordering::Release);
                 cache::make_value(&self.config, key, req_id)
             })
@@ -276,7 +276,7 @@ impl GetWith {
             InitClosureType::GetOrTryInsertWithError1 => self
                 .cache
                 .try_get_with(key, async {
-                    cache::sleep_task_for_insertion(&self.config).await;
+                    cache::sleep_thread_for_insertion(&self.config);
                     is_inserted.store(true, Ordering::Release);
                     Ok(cache::make_value(&self.config, key, req_id)) as Result<_, InitClosureError1>
                 })
@@ -285,7 +285,7 @@ impl GetWith {
             InitClosureType::GetOrTyyInsertWithError2 => self
                 .cache
                 .try_get_with(key, async {
-                    cache::sleep_task_for_insertion(&self.config).await;
+                    cache::sleep_thread_for_insertion(&self.config);
                     is_inserted.store(true, Ordering::Release);
                     Ok(cache::make_value(&self.config, key, req_id)) as Result<_, InitClosureError2>
                 })
@@ -345,7 +345,7 @@ mod entry_api {
             self.cache
                 .entry(key)
                 .or_insert_with(async {
-                    cache::sleep_task_for_insertion(&self.config).await;
+                    cache::sleep_thread_for_insertion(&self.config);
                     cache::make_value(&self.config, key, req_id)
                 })
                 .await
@@ -363,7 +363,7 @@ mod entry_api {
                     .cache
                     .entry(key)
                     .or_try_insert_with(async {
-                        cache::sleep_task_for_insertion(&self.config).await;
+                        cache::sleep_thread_for_insertion(&self.config);
                         Ok(cache::make_value(&self.config, key, req_id))
                             as Result<_, InitClosureError1>
                     })
@@ -374,7 +374,7 @@ mod entry_api {
                     .cache
                     .entry(key)
                     .or_try_insert_with(async {
-                        cache::sleep_task_for_insertion(&self.config).await;
+                        cache::sleep_thread_for_insertion(&self.config);
                         Ok(cache::make_value(&self.config, key, req_id))
                             as Result<_, InitClosureError2>
                     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,6 @@ pub fn run_multi_threads_hashlink(
 }
 
 #[cfg(feature = "quick_cache")]
-#[allow(clippy::needless_collect)] // on the `handles` variable.
 pub fn run_multi_threads_quick_cache(
     config: &Config,
     capacity: usize,
@@ -184,7 +183,6 @@ pub fn run_multi_threads_quick_cache(
 }
 
 #[cfg(feature = "stretto")]
-#[allow(clippy::needless_collect)] // on the `handles` variable.
 pub fn run_multi_threads_stretto(
     config: &Config,
     capacity: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,10 +93,6 @@ async fn run_with_capacity(config: &Config, capacity: usize) -> anyhow::Result<(
         }
     }
 
-    if capacity >= 2_000_000 {
-        return Ok(());
-    }
-
     for num_clients in num_clients_slice {
         let report = mokabench::run_multi_threads_moka_sync(config, capacity, *num_clients)?;
         println!("{}", report.to_csv_record());


### PR DESCRIPTION
- Add more command examples to the README.
- In order to make the `--insertion-delay` μs consistent across cache implementations, change Moka's async cache to use `std::thread::sleep` like other caches.
- Run all cache sizes of DS1 benchmarks with Moka.
    - Memory leak in Moka was fixed a while ago.
- Remove unnecessary Clippy allow lint attributes.