### PR TITLE
Support TinyUFO

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,12 @@
 {
     "editor.rulers": [85],
-    "rust-analyzer.cargo.features": ["hashlink", "mini-moka", "quick_cache", "stretto"],
+    "rust-analyzer.cargo.features": [
+        "hashlink",
+        "mini-moka",
+        "quick_cache",
+        "stretto",
+        "tiny-ufo"
+    ],
     "rust-analyzer.server.extraEnv": {
         "CARGO_TARGET_DIR": "target/ra"
     },
@@ -16,6 +22,7 @@
         "mokabench",
         "oltp",
         "thiserror",
+        "tinyufo",
         "Toolchain",
         "unsync",
         "Zstandard"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "TinyUFO"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391696fbe4cde5f4c71cd78eb71d706bbdf2d60cc875cd31b412caa9ce54b739"
+dependencies = [
+ "ahash 0.8.11",
+ "crossbeam-queue",
+ "flurry",
+ "parking_lot",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +28,17 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "ahash"
@@ -408,6 +431,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils 0.8.19",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +562,18 @@ name = "fastrand"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+
+[[package]]
+name = "flurry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0afc943ef18eebf6bc3335daeb8d338202093d18444a1784ea7f57fe7680f8"
+dependencies = [
+ "ahash 0.7.8",
+ "num_cpus",
+ "parking_lot",
+ "seize",
+]
 
 [[package]]
 name = "futures-channel"
@@ -658,7 +702,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -987,6 +1031,7 @@ dependencies = [
 name = "mokabench"
 version = "0.10.0"
 dependencies = [
+ "TinyUFO",
  "anyhow",
  "async-io 1.13.0",
  "async-std",
@@ -1203,7 +1248,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "347e1a588d1de074eeb3c00eadff93db4db65aeb62aee852b1efd0949fe65b6c"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "equivalent",
  "hashbrown 0.14.3",
  "parking_lot",
@@ -1352,6 +1397,16 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "seize"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5739de653b129b0a59da381599cf17caf24bc586f6a797c52d3d6147c5b85a"
+dependencies = [
+ "num_cpus",
+ "once_cell",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ hashlink = ["dep:hashlink"]
 mini-moka = ["dep:mini-moka"]
 quick_cache = ["dep:quick_cache"]
 stretto = ["dep:stretto"]
+tiny-ufo = ["dep:TinyUFO"]
 
 rt-tokio = ["dep:tokio"]
 rt-async-std = ["dep:async-std"]
@@ -42,6 +43,7 @@ hashlink = { optional = true, version = "0.8.1" }
 mini-moka = { optional = true, version = "0.10.0" }
 quick_cache = { optional = true, version = "0.5" }
 stretto = { optional = true, version = "0.7.1" }
+TinyUFO = { optional = true, version = "0.1" }
 
 [dependencies.moka012]
 package = "moka"

--- a/README.md
+++ b/README.md
@@ -105,8 +105,11 @@ $ cargo build --release --no-default-features -F moka-v09,rt-tokio
 | `mini-moka`   | [Mini-Moka](https://crates.io/crates/mini-moka) |
 | `quick_cache` | [quick_cache](https://crates.io/crates/quick_cache) |
 | `stretto`     | [Stretto](https://crates.io/crates/stretto) |
+| `tiny-ufo`    | [TinyUFO](https://crates.io/crates/TinyUFO) |
 
 **Features to select async runtime:**
+
+Only used by Moka async cache.
 
 | Feature        | Enabled Cache Product |
 |:---------------|:----------------------|

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -18,6 +18,8 @@ pub(crate) mod moka_driver;
 pub(crate) mod quick_cache;
 #[cfg(feature = "stretto")]
 pub(crate) mod stretto;
+#[cfg(feature = "tiny-ufo")]
+pub(crate) mod tiny_ufo;
 
 pub(crate) type Key = usize;
 pub(crate) type Value = (u32, Arc<[u8]>);

--- a/src/cache/tiny_ufo.rs
+++ b/src/cache/tiny_ufo.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use super::{CacheDriver, Counters, Key, Value};
+use crate::{config::Config, parser::TraceEntry, report::Report};
+
+#[derive(Clone)]
+pub struct TinyUfoCache {
+    config: Arc<Config>,
+    cache: Arc<tinyufo::TinyUfo<Key, Value>>,
+}
+
+impl TinyUfoCache {
+    pub fn new(config: &Config, capacity: usize) -> Self {
+        if let Some(_ttl) = config.ttl {
+            todo!()
+        }
+        if let Some(_tti) = config.tti {
+            todo!()
+        }
+        if config.size_aware {
+            todo!()
+        }
+
+        // TinyUFO does not support custom hasher. Use its default hasher.
+        Self {
+            config: Arc::new(config.clone()),
+            cache: Arc::new(tinyufo::TinyUfo::new(capacity, capacity)),
+        }
+    }
+
+    fn get(&self, key: &usize) -> bool {
+        self.cache.get(key).is_some()
+    }
+
+    fn insert(&self, key: usize, req_id: usize) {
+        let value = super::make_value(&self.config, key, req_id);
+        super::sleep_thread_for_insertion(&self.config);
+        self.cache.put(key, value, 1);
+    }
+}
+
+impl CacheDriver<TraceEntry> for TinyUfoCache {
+    fn get_or_insert(&mut self, entry: &TraceEntry, report: &mut Report) {
+        let mut counters = Counters::default();
+        let mut req_id = entry.line_number();
+
+        for block in entry.range() {
+            if self.get(&block) {
+                counters.read_hit();
+            } else {
+                self.insert(block, req_id);
+                counters.inserted();
+                counters.read_missed();
+            }
+            req_id += 1;
+        }
+
+        counters.add_to_report(report);
+    }
+
+    fn get_or_insert_once(&mut self, _entry: &TraceEntry, _report: &mut Report) {
+        unimplemented!();
+    }
+
+    fn update(&mut self, entry: &TraceEntry, report: &mut Report) {
+        let mut counters = Counters::default();
+        let mut req_id = entry.line_number();
+
+        for block in entry.range() {
+            self.insert(block, req_id);
+            counters.inserted();
+            req_id += 1;
+        }
+
+        counters.add_to_report(report);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,8 @@ use crate::cache::mini_moka_driver::{
 use crate::cache::quick_cache::QuickCache;
 #[cfg(feature = "stretto")]
 use crate::cache::stretto::StrettoCache;
+#[cfg(feature = "tiny-ufo")]
+use crate::cache::tiny_ufo::TinyUfoCache;
 
 const BATCH_SIZE: usize = 200;
 
@@ -206,6 +208,17 @@ pub fn run_multi_threads_stretto(
 ) -> anyhow::Result<Report> {
     let cache_driver = StrettoCache::new(config, capacity);
     let report_builder = ReportBuilder::new("Stretto", capacity as _, Some(num_clients));
+    run_multi_threads(config, num_clients, cache_driver, report_builder)
+}
+
+#[cfg(feature = "tiny-ufo")]
+pub fn run_multi_threads_tiny_ufo(
+    config: &Config,
+    capacity: usize,
+    num_clients: u16,
+) -> anyhow::Result<Report> {
+    let cache_driver = TinyUfoCache::new(config, capacity);
+    let report_builder = ReportBuilder::new("TinyUFO", capacity as _, Some(num_clients));
     run_multi_threads(config, num_clients, cache_driver, report_builder)
 }
 


### PR DESCRIPTION
Add support for [`TinyUFO`](https://crates.io/crates/TinyUFO) crate. Use `tiny-lfo` feature to enable it.